### PR TITLE
Add mocking, mention /add in readme, add CI build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
   workflow_dispatch:
 jobs:
-  test:
+  lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -16,3 +16,16 @@ jobs:
         run: npm install
       - name: Lint
         run: npm run lint
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -73,5 +73,14 @@ the type definitions of requests and responses, which is standard for RESTful AP
 which will export definitions in both formats so that we only have to write them once. We define these models in the 'shared'
 directory (`shared/`), which the backend and frontend both import to access the type definitions.
 
+### Full Stack Example
+For an example of a what a route will look like with its backend implementation, shared types, and its frontend usage,
+look at the `/add` example route:
+- For the types, look at `/shared/src/model/add.model.ts`. Note how we export all of the needed exports in `/shared/src/index.ts`.
+- For the backend implementation, look at `/server/src/routes/add/root.ts`.
+  - Here you can see an example of how to mock a route while its still in development (using `Value.Create()`), but also
+    a simple example of how to implement the route once we are done mocking that route.
+- For the frontend implementation, look at `/web/src/client/add.ts` and the bottom of `/web/src/components/main.tsx`.
+
 ## Deployment
 For now, we have no plans to deploy this anywhere. It can be run on a local computer for testing and presentation.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3921,7 +3921,7 @@
       "version": "0.33.12",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.12.tgz",
       "integrity": "sha512-d5KrXIdPolLp8VpGpZAQvEz8ioVtFlUQSyCIS2sEBi7FKhceIB7nj9BlNfqqvp5wmOfg8v8bP1rAvYYkjz21/Q==",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -15131,6 +15131,7 @@
         "@fastify/autoload": "^6.0.0",
         "@fastify/cors": "^10.0.0",
         "@fastify/type-provider-typebox": "^5.0.0",
+        "@sinclair/typebox": "^0.33.12",
         "fastify": "^5.0.0",
         "pino": "^9.4.0",
         "pino-pretty": "^11.2.2",

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "@fastify/autoload": "^6.0.0",
     "@fastify/cors": "^10.0.0",
     "@fastify/type-provider-typebox": "^5.0.0",
+    "@sinclair/typebox": "^0.33.12",
     "fastify": "^5.0.0",
     "pino": "^9.4.0",
     "pino-pretty": "^11.2.2",

--- a/server/src/routes/add/root.ts
+++ b/server/src/routes/add/root.ts
@@ -1,5 +1,6 @@
 import { TypeBoxTypeProvider, FastifyPluginAsyncTypebox } from '@fastify/type-provider-typebox'
 import { AddResponseSchema, AddRequestSchema } from 'shared'
+import { Value } from '@sinclair/typebox/value'
 
 // maybe use a generic argument for FastifyPluginAsync if we use options with fastify instance
 const add: FastifyPluginAsyncTypebox = async (fastifyApp, { }): Promise<void> => {
@@ -13,8 +14,14 @@ const add: FastifyPluginAsyncTypebox = async (fastifyApp, { }): Promise<void> =>
             }
         }
     }, async (request, reply) => {
-        const { a, b } = request.query
-        reply.status(200).send({ result: a + b})
+        // Example of implemeting the route
+        // const { a, b } = request.query
+        // const response = { result: a + b }
+
+        // Example of mocking a route with Typebox
+        const response = Value.Create(AddResponseSchema)
+
+        reply.status(200).send(response)
     })
 }
 

--- a/shared/src/model/add.model.ts
+++ b/shared/src/model/add.model.ts
@@ -1,7 +1,9 @@
 import { Static, Type } from '@fastify/type-provider-typebox'
 
+// Best to use default values (i.e. { default: ... }) for Response types. They aren't as useful for request types.
+
 export const AddResponseSchema = Type.Object({
-  result: Type.Number()
+  result: Type.Number({ default: 42 })
 })
 export type AddResponse = Static<typeof AddResponseSchema>
 


### PR DESCRIPTION
- Mention the sample route in the readme
- Add a build to the CI, especially since you can test the frontend with `npm run frontend` but that doesn't actually build it and there can be errors that you don't see unless you explicitly build.
- Add the mocking example using Value.Create() from typebox.