### PR TITLE
Implement get products route

### DIFF
--- a/server/src/routes/products/root.ts
+++ b/server/src/routes/products/root.ts
@@ -27,10 +27,13 @@ const getProduct: FastifyPluginAsyncTypebox = async (fastifyApp): Promise<void> 
     logger.info(process.env.STORE_URL)
 
     const client = new ShopifyGraphQLClient(process.env.ACCESS_TOKEN, process.env.STORE_URL)
-    const products = await getProducts(client, request.query.pageSize)
+    const pageSize = request.query.pageSize
+    const before = request.query.before ?? null
+    const after = request.query.after ?? null
+    const [products, pageInfo] = await getProducts(client, pageSize, before, after)
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    reply.status(200).send({ result: products })
+    reply.status(200).send({ result: products, pageInfo: pageInfo })
   })
 }
 

--- a/server/src/routes/products/root.ts
+++ b/server/src/routes/products/root.ts
@@ -33,7 +33,7 @@ const getProduct: FastifyPluginAsyncTypebox = async (fastifyApp): Promise<void> 
     const [products, pageInfo] = await getProducts(client, pageSize, before, after)
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    reply.status(200).send({ result: products, pageInfo: pageInfo })
+    reply.status(200).send({ result: products, pageInfo })
   })
 }
 

--- a/server/src/shopify/product.ts
+++ b/server/src/shopify/product.ts
@@ -1,5 +1,6 @@
 import { ShopifyGraphQLClient } from './shopify-client'
 import { logger } from '../util/logger'
+import { Product } from 'shared'
 
 const getProductByIdQuery = /* GraphQL */ `
   query productById($id: ID!) {
@@ -22,6 +23,7 @@ const getProductByIdQuery = /* GraphQL */ `
         }
       }
       title
+      totalInventory
       images(first: 1) {
         nodes {
           url
@@ -35,7 +37,7 @@ const getProductByIdQuery = /* GraphQL */ `
 export async function getProductById (
   client: ShopifyGraphQLClient,
   id: string
-): Promise<string | null> {
+): Promise<Product | null> {
   const { data, errors } = await client.request(getProductByIdQuery, {
     id: `gid://shopify/Product/${id}`
   }) as any
@@ -47,5 +49,71 @@ export async function getProductById (
     throw errors
   }
 
-  return data?.product?.title != null ? data?.product?.title : null
+  if (data?.product == null) {
+    return null
+  }
+
+  return {
+    id: data?.product.id,
+    title: data?.product.title,
+    totalInventory: data?.product.totalInventory
+  }
+}
+
+const getProductsQuery = /* TODO: page Size */ `
+  query {
+    products(first: 10) {
+      nodes {
+          id
+          title
+          totalInventory
+          handle
+          variantsCount {
+              count
+              precision
+          }
+          variants(first: 20) {
+              nodes {
+                  title
+                  sku
+                  displayName
+                  inventoryQuantity
+              }
+          }
+      }
+      pageInfo {
+          hasPreviousPage
+          hasNextPage
+          startCursor
+          endCursor
+      }
+    }
+  }
+`
+
+export async function getProducts (
+  client: ShopifyGraphQLClient,
+  pageSize: number
+): Promise<Product[]> {
+  const { data, errors } = await client.request(getProductsQuery, {
+    // pageSize: `${pageSize}`
+  }) as any
+
+  logger.info(data)
+  logger.info(errors)
+
+  if (errors != null) {
+    throw errors
+  }
+
+  const products: Product[] = []
+  for (const prod of data?.products.nodes) {
+    products.push({
+      id: prod.id,
+      title: prod.title,
+      totalInventory: prod.totalInventory
+    })
+  }
+
+  return products
 }

--- a/server/src/shopify/product.ts
+++ b/server/src/shopify/product.ts
@@ -103,8 +103,8 @@ export async function getProducts (
   const { data, errors } = await client.request(getProductsQuery, {
     last: (before == null) ? null : pageSize,
     first: (before == null) ? pageSize : null,
-    before: before,
-    after: after
+    before,
+    after
   }) as any
 
   logger.info(data)

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,3 +1,4 @@
 // Add a line for each file in the model folder
 export * from './model/add.model'
 export * from './model/product.model'
+export * from './model/response.model'

--- a/shared/src/model/product.model.ts
+++ b/shared/src/model/product.model.ts
@@ -1,15 +1,29 @@
 import { Static, Type } from '@fastify/type-provider-typebox'
 
 // Best to use default values (i.e. { default: ... }) for Response types. They aren't as useful for request types.
-
-export const GetProductResponseSchema = Type.Object({
-  result: Type.Object({
-    title: Type.String()
-  })
+export const ProductSchema = Type.Object({
+  id: Type.String(),
+  title: Type.String(),
+  totalInventory: Type.Integer()
 })
-export type GetProductResponse = Static<typeof GetProductResponseSchema>
+export type Product = Static<typeof ProductSchema>
 
 export const GetProductRequestSchema = Type.Object({
   id: Type.String()
 })
 export type GetProductRequest = Static<typeof GetProductRequestSchema>
+
+export const GetProductResponseSchema = Type.Object({
+  result: ProductSchema
+})
+export type GetProductResponse = Static<typeof GetProductResponseSchema>
+
+export const GetProductsRequestSchema = Type.Object({
+  pageSize: Type.Integer()
+})
+export type GetProductsRequest = Static<typeof GetProductsRequestSchema>
+
+export const GetProductsResponseSchema = Type.Object({
+  result: Type.Array(ProductSchema)
+})
+export type GetProductsResponse = Static<typeof GetProductsResponseSchema>

--- a/shared/src/model/product.model.ts
+++ b/shared/src/model/product.model.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from '@fastify/type-provider-typebox'
-import { PageInfoSchema } from "./response.model";
+import { PageInfoSchema } from './response.model'
 
 // Best to use default values (i.e. { default: ... }) for Response types. They aren't as useful for request types.
 export const ProductSchema = Type.Object({
@@ -22,7 +22,7 @@ export type GetProductResponse = Static<typeof GetProductResponseSchema>
 export const GetProductsRequestSchema = Type.Object({
   pageSize: Type.Integer(),
   after: Type.Optional(Type.String()),
-  before: Type.Optional(Type.String()),
+  before: Type.Optional(Type.String())
 })
 export type GetProductsRequest = Static<typeof GetProductsRequestSchema>
 

--- a/shared/src/model/product.model.ts
+++ b/shared/src/model/product.model.ts
@@ -1,4 +1,5 @@
 import { Static, Type } from '@fastify/type-provider-typebox'
+import { PageInfoSchema } from "./response.model";
 
 // Best to use default values (i.e. { default: ... }) for Response types. They aren't as useful for request types.
 export const ProductSchema = Type.Object({
@@ -19,11 +20,14 @@ export const GetProductResponseSchema = Type.Object({
 export type GetProductResponse = Static<typeof GetProductResponseSchema>
 
 export const GetProductsRequestSchema = Type.Object({
-  pageSize: Type.Integer()
+  pageSize: Type.Integer(),
+  after: Type.Optional(Type.String()),
+  before: Type.Optional(Type.String()),
 })
 export type GetProductsRequest = Static<typeof GetProductsRequestSchema>
 
 export const GetProductsResponseSchema = Type.Object({
-  result: Type.Array(ProductSchema)
+  result: Type.Array(ProductSchema),
+  pageInfo: PageInfoSchema
 })
 export type GetProductsResponse = Static<typeof GetProductsResponseSchema>

--- a/shared/src/model/response.model.ts
+++ b/shared/src/model/response.model.ts
@@ -1,0 +1,9 @@
+import {Static, Type} from "@fastify/type-provider-typebox";
+
+export const PageInfoSchema = Type.Object({
+    hasNextPage: Type.Boolean(),
+    hasPreviousPage: Type.Boolean(),
+    startCursor: Type.String(),
+    endCursor: Type.String(),
+});
+export type PageInfo = Static<typeof PageInfoSchema>

--- a/shared/src/model/response.model.ts
+++ b/shared/src/model/response.model.ts
@@ -1,9 +1,9 @@
-import {Static, Type} from "@fastify/type-provider-typebox";
+import { Static, Type } from '@fastify/type-provider-typebox'
 
 export const PageInfoSchema = Type.Object({
-    hasNextPage: Type.Boolean(),
-    hasPreviousPage: Type.Boolean(),
-    startCursor: Type.String(),
-    endCursor: Type.String(),
-});
+  hasNextPage: Type.Boolean(),
+  hasPreviousPage: Type.Boolean(),
+  startCursor: Type.String(),
+  endCursor: Type.String()
+})
 export type PageInfo = Static<typeof PageInfoSchema>


### PR DESCRIPTION
Implements the basic structure for a get-products endpoint. This includes the API and back-end structure for retrieving a list of products from Shopify, as well as functionality to implement pagination. The data returned is not complete, pending architectural decisions regarding what data we need and where we get it from, but those will be relatively minor changes. 

Includes some changes to the product model which will likely conflict with work Caleb has done. I also made some decisions regarding file structure, but it may be preferable to separate some things out (such as server/src/routes/products/root.ts).